### PR TITLE
Graceful deletion of child records

### DIFF
--- a/app/routes/customers.js
+++ b/app/routes/customers.js
@@ -12,4 +12,29 @@ export default Ember.Route.extend({
 
     return Ember.RSVP.all(promises);
   },
+
+  actions: {
+    deleteCustomer(customer) {
+      let confirmation = confirm('Are you sure?');
+
+      if (confirmation) {
+	customer.get('invoices').forEach(
+          invoice => {
+            invoice.destroyRecord();
+          }
+        )
+
+        customer.destroyRecord();
+      }
+    },
+
+    saveCustomer(customer) {
+      customer.validate()
+        .then(({ validations }) => {
+          if (validations.get('isValid')) {
+            customer.save().then(() => this.transitionTo('customers'));
+          }
+        })
+    },
+  }
 });

--- a/app/routes/customers.js
+++ b/app/routes/customers.js
@@ -18,13 +18,24 @@ export default Ember.Route.extend({
       let confirmation = confirm('Are you sure?');
 
       if (confirmation) {
-	customer.get('invoices').forEach(
-          invoice => {
-            invoice.destroyRecord();
-          }
-        )
 
-        customer.destroyRecord();
+        let deletedInvoices = [];
+
+        customer.get('invoices').then(
+          invoices => {
+            invoices.map(
+              invoice => {
+                deletedInvoices.push(invoice.destroyRecord());
+              }
+            );
+          }
+        );
+
+        Ember.RSVP.all(deletedInvoices).then(
+          () => {
+            customer.destroyRecord();
+          }
+        );
       }
     },
 

--- a/app/routes/customers.js
+++ b/app/routes/customers.js
@@ -14,11 +14,13 @@ export default Ember.Route.extend({
   },
 
   actions: {
+    // Delete customer and all associated invoices
     deleteCustomer(customer) {
       let confirmation = confirm('Are you sure?');
 
       if (confirmation) {
 
+        // Array of deletions to execute
         let deletedInvoices = [];
 
         customer.get('invoices').then(
@@ -31,6 +33,7 @@ export default Ember.Route.extend({
           }
         );
 
+        // Delete all invoices then delete customer
         Ember.RSVP.all(deletedInvoices).then(
           () => {
             customer.destroyRecord();
@@ -39,11 +42,17 @@ export default Ember.Route.extend({
       }
     },
 
+    // Save a new or modified customer record
     saveCustomer(customer) {
+      // The 'save' button should only enable when the model is valid,
+      // but better safe than sorry
       customer.validate()
         .then(({ validations }) => {
           if (validations.get('isValid')) {
             customer.save().then(() => this.transitionTo('customers'));
+          } else {
+            // FIXME: Display errors properly
+            alert("Please fix errors before saving.")
           }
         })
     },

--- a/app/routes/customers/edit.js
+++ b/app/routes/customers/edit.js
@@ -18,15 +18,6 @@ export default Ember.Route.extend({
   },
 
   actions: {
-    saveCustomer(newCustomer) {
-      newCustomer.validate()
-        .then(({ validations }) => {
-          if (validations.get('isValid')) {
-            newCustomer.save().then(() => this.transitionTo('customers'));
-          }
-        })
-    },
-
     willTransition(transition) {
       let model = this.controller.get('model')
 

--- a/app/routes/customers/index.js
+++ b/app/routes/customers/index.js
@@ -4,15 +4,4 @@ export default Ember.Route.extend({
   model() {
     return this.store.findAll('customer');
   },
-
-  actions: {
-
-    deleteCustomer(customer) {
-      let confirmation = confirm('Are you sure?');
-
-      if (confirmation) {
-        customer.destroyRecord();
-      }
-    }
-  }
 });

--- a/app/routes/customers/new.js
+++ b/app/routes/customers/new.js
@@ -17,16 +17,6 @@ export default Ember.Route.extend({
   },
 
   actions: {
-
-    saveCustomer(newCustomer) {
-      newCustomer.validate()
-        .then(({ validations }) => {
-          if (validations.get('isValid')) {
-            newCustomer.save().then(() => this.transitionTo('customers'));
-          }
-        })
-    },
-
     willTransition(transition) {
       let model = this.controller.get('model')
 

--- a/app/routes/invoices.js
+++ b/app/routes/invoices.js
@@ -22,7 +22,6 @@ export default Ember.Route.extend({
 
         customer.get('invoices').removeObject(invoice).then(
           () => {
-            console.log(customer)
             customer.save().then(
               () => {
                 invoice.destroyRecord();

--- a/app/routes/invoices.js
+++ b/app/routes/invoices.js
@@ -46,23 +46,37 @@ export default Ember.Route.extend({
       }
     },
 
+    // Save a new or modified invoice record
     saveInvoice(invoice) {
+      // The 'save' button should only enable when the model is valid,
+      // but better safe than sorry
       invoice.validate()
         .then(({ validations }) => {
           if (validations.get('isValid')) {
+            // It is safe to save the child record first here as
+            // there are no valid states in which the parent (customer)
+            // is unsaved
             invoice.save().then(
               invoice => {
+                // Get the customer record via the belongsTo reference
                 let customer = invoice.belongsTo('customer').value();
+
+                // If the customer's array already has a record with the
+                // invoice's ID it will be updated rather than duplicated
                 customer.get('invoices').pushObject(invoice)
+
                 customer.save().then(
                   () => this.transitionTo('invoices')
                 )
               },
               error => {
                 alert(error)
-                // FIXME: Display errors properly.
+                // FIXME: Display errors properly
               }
             )
+          } else {
+            // FIXME: Display errors properly
+            alert("Please fix errors before saving.")
           }
         })
     },

--- a/app/routes/invoices/edit.js
+++ b/app/routes/invoices/edit.js
@@ -27,8 +27,6 @@ export default Ember.Route.extend({
   },
 
   actions: {
-
-
    addLine() {
       let line = this.controller.get('line');
       let invoice = this.controller.get('invoice');
@@ -53,27 +51,6 @@ export default Ember.Route.extend({
           // FIXME: Display errors properly.
         }
       )
-    },
-
-    saveInvoice(existingInvoice) {
-      existingInvoice.validate()
-        .then(({ validations }) => {
-          if (validations.get('isValid')) {
-            existingInvoice.save().then(
-              invoice => {
-                let customerRef = invoice.belongsTo('customer');
-                let customer = customerRef.value();
-
-                customer.get('invoices').pushObject(invoice)
-                customer.save().then(this.transitionTo('invoices'))
-              },
-              error => {
-                alert(error)
-                // FIXME: Display errors.
-              }
-            )
-          }
-        })
     },
 
     willTransition(transition) {

--- a/app/routes/invoices/new.js
+++ b/app/routes/invoices/new.js
@@ -49,27 +49,6 @@ export default Ember.Route.extend({
       )
     },
 
-    saveInvoice(newInvoice) {
-      newInvoice.validate()
-        .then(({ validations }) => {
-          if (validations.get('isValid')) {
-            newInvoice.save().then(
-              invoice => {
-                let customerRef = invoice.belongsTo('customer');
-                let customer = customerRef.value();
-                customer.get('invoices').pushObject(invoice)
-
-                customer.save().then(this.transitionTo('invoices'))
-              },
-              error => {
-                alert(error)
-                // FIXME: Display errors properly.
-              }
-            )
-          }
-        })
-    },
-
     willTransition(transition) {
       let invoice = this.controller.get('invoice');
 


### PR DESCRIPTION
Deleting a record will currently cause the application to enter an unrecoverable state of weird behaviour. For example, deleting an invoice without deleting it from the customer's invoices list will result in console errors and empty invoice cards appearing in the invoices list.

The application must:

* Delete an invoice from the customer's invoice list _before_ deleting the invoice itself.
* Delete all invoices belonging to a customer when deleting a customer record.